### PR TITLE
Fix missing matplotlib import in WFA metrics

### DIFF
--- a/metrics/wfa_metrics.py
+++ b/metrics/wfa_metrics.py
@@ -1,6 +1,7 @@
 import pandas as pd
 import numpy as np
 import vectorbt as vbt
+import matplotlib.pyplot as plt
 from typing import Dict, List
 
 def compute_sharpe(returns: pd.Series, annualization_factor: int = 252) -> float:


### PR DESCRIPTION
## Summary
- import `matplotlib.pyplot` in `wfa_metrics`

## Testing
- `python -m py_compile metrics/wfa_metrics.py`
- `python - <<'EOF'
from metrics import wfa_metrics
EOF` *(fails: ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_e_68446f34a5148325886c0169460a5c37